### PR TITLE
Make wallets directory configurable

### DIFF
--- a/lib/http/utils/create-wallet.js
+++ b/lib/http/utils/create-wallet.js
@@ -2,12 +2,15 @@ const fs = require('fs');
 const ethers = require('ethers');
 const path = require('path');
 
+const keysDirectory = process.env.COINSENCE_WALLETS_DIR || path.join(__dirname, '../../../', 'keys');
+
 module.exports = function createEncryptedWallet(accountId, password) {
   const wallet = ethers.Wallet.createRandom();
 
   return wallet.encrypt(password).then(res => {
     return new Promise((resolve, reject) => {
-      fs.writeFile(path.join(__dirname, '../../../', 'keys', `${accountId}.json`), res, { flag: 'ax' }, (err) => {
+      const walletPath = path.join(keysDirectory, `${accountId}.json`);
+      fs.writeFile(walletPath, res, { flag: 'ax' }, (err) => {
         if (err) reject(err);
         else resolve(wallet);
       });

--- a/lib/http/utils/load-wallet.js
+++ b/lib/http/utils/load-wallet.js
@@ -2,9 +2,11 @@ const fs = require('fs');
 const ethers = require('ethers');
 const path = require('path');
 
+const keysDirectory = process.env.COINSENCE_WALLETS_DIR || path.join(__dirname, '../../../', 'keys');
+
 module.exports = function (accountId, password) {
   return new Promise((resolve, reject) => {
-    const walletPath = path.join(__dirname, '../../../', 'keys', `${accountId}.json`);
+    const walletPath = path.join(keysDirectory, `${accountId}.json`);
     fs.readFile(walletPath, (err, walletJson) => {
       if (err) reject(err);
       else resolve(ethers.Wallet.fromEncryptedJson(walletJson, password));


### PR DESCRIPTION
The directory where we store the wallet files is now configurable
through the COINSENCE_WALLETS_DIR environment variable.
This makes it easier to deploy the app and to store the keys outside of
the repository directory.