### PR TITLE
Only fund new wallets with 0.3 eth

### DIFF
--- a/lib/http/apps/wallet.js
+++ b/lib/http/apps/wallet.js
@@ -14,7 +14,7 @@ app.post(`/`, (req, res) => {
     if (res.locals.coinsenceSigner) {
       res.locals.coinsenceSigner.sendTransaction({
         to: wallet.address,
-        value: ethers.utils.parseEther('1')
+        value: ethers.utils.parseEther('0.3')
       });
     }
     res.status(201).json({


### PR DESCRIPTION
We fund each wallet with some initial ETH for gas. To not run out of funds we need to optimize and spend less. 