### PR TITLE
Only transfer 0.1 eth to every new wallet

### DIFF
--- a/lib/http/apps/wallet.js
+++ b/lib/http/apps/wallet.js
@@ -14,7 +14,7 @@ app.post(`/`, (req, res) => {
     if (res.locals.coinsenceSigner) {
       res.locals.coinsenceSigner.sendTransaction({
         to: wallet.address,
-        value: ethers.utils.parseEther('0.3')
+        value: ethers.utils.parseEther('0.1')
       });
     }
     res.status(201).json({


### PR DESCRIPTION
since we pay the DAO fees from a central wallet the actual wallets should not need that much ETH. 
0.1 ETH should be enough for quite some contract calls. and we should further limit that number in the future. 