### PR TITLE
Refactor Coin app

### DIFF
--- a/apps/coin/contracts/Coin.sol
+++ b/apps/coin/contracts/Coin.sol
@@ -23,14 +23,14 @@ contract Coin is StandardCoin, AragonApp {
     string private _symbol;
     ///@notice coin decimals
     uint8 private _decimals;
-    ///@notice coin state (false=not yet issued)
-    bool internal _isIssued;
 
     /**
      * @notice init coin
      */
-    function initialize() public onlyInit {
-        _isIssued = false;
+    function initialize(string memory name, string memory symbol, uint8 decimals) public onlyInit {
+        _name = name;
+        _symbol = symbol;
+        _decimals = decimals;
 
         initialized();
     }
@@ -57,21 +57,6 @@ contract Coin is StandardCoin, AragonApp {
      */
     function decimal() public view isInitialized returns(uint8) {
         return _decimals;
-    }
-
-    /**
-     * @notice issue coin
-     * @param name coin name
-     * @param symbol coin symbol
-     * @param decimals coin decimal
-     */
-    function issueCoin(string memory name, string memory symbol, uint8 decimals) public isInitialized auth(ISSUE_ROLE) {
-        require(!_isIssued, "Coin already issued");
-        _name = name;
-        _symbol = symbol;
-        _decimals = decimals;
-
-        _isIssued = true;
     }
 
     /**

--- a/apps/coin/test/coin.js
+++ b/apps/coin/test/coin.js
@@ -7,11 +7,16 @@ const ZERO_ADDR = '0x0000000000000000000000000000000000000000';
 
 contract('Coin app', (accounts) => {
     let kernelBase, aclBase, daoFactory, dao, acl, coin;
+    let coinName, coinSymbol, coinDecimals;
   
     const root = accounts[0];
     const member1 = accounts[1];
   
     before(async() => {
+      coinName = "Coinsence Coin";
+      coinSymbol = "CC";
+      coinDecimals = 18;
+
       kernelBase = await getContract('Kernel').new(true) // petrify immediately
       aclBase = await getContract('ACL').new()
       daoFactory = await getContract('DAOFactory').new(kernelBase.address, aclBase.address, ZERO_ADDR);
@@ -41,7 +46,7 @@ contract('Coin app', (accounts) => {
       )
   
       //init coin (app)
-      await coin.initialize();
+      await coin.initialize(coinName, coinSymbol, coinDecimals);
   
       //create coin issuer permission for coin owner
       await acl.createPermission(
@@ -71,29 +76,10 @@ contract('Coin app', (accounts) => {
     });
 
     describe("Coin issuing", async () => {
-      let name = "coinsence";
-      let symbol = "cc";
-      let decimals = 18;
-
-      it("should revert when issuing a coin from an address that does not have issuing permission", async() => {
-        return assertRevert(async () => {
-          await coin.issueCoin(name, symbol, decimals, { from: member1 })
-          'address does not have permission to issue token'
-        })
-      });
-
-      it("issue token", async() => {
-        await coin.issueCoin(name, symbol, decimals, { from: root });
-        assert.equal(await coin.name(), name);
-        assert.equal(await coin.symbol(), symbol);
-        assert.equal(await coin.decimal(), decimals);
-      });
-
-      it("should revert when issuing an already issued coin", async() => {
-        return assertRevert(async () => {
-          await coin.issueCoin(name, symbol, decimals, { from: root })
-          'address does not have permission to issue token'
-        })
+      it("Check coin parameters", async() => {
+        assert.equal(await coin.name(), coinName);
+        assert.equal(await coin.symbol(), coinSymbol);
+        assert.equal(await coin.decimal(), coinDecimals);
       });
     });
 

--- a/apps/coinsence-kit/contracts/CoinsenceKit.sol
+++ b/apps/coinsence-kit/contracts/CoinsenceKit.sol
@@ -54,21 +54,30 @@ contract CoinsenceKit is KitBase {
     KitBase(_ens) public {
     }
 
-    function newInstance(string name, bytes32 descHash, address root) public {
+    function newInstance(string spaceName, bytes32 descHash, string coinName, string coinSymbol, uint8 coinDecimals, address root) public {
         Kernel dao = fac.newDAO(this);
         ACL acl = ACL(dao.acl());
 
         bytes32 appManagerRole = dao.APP_MANAGER_ROLE();
         acl.createPermission(this, dao, appManagerRole, this);
 
-        createCSApps(root, dao, name, descHash);
+        createCSApps(root, dao, spaceName, descHash, coinName, coinSymbol, coinDecimals);
 
         handleCleanupPermissions(dao, acl, root);
 
         emit DeployInstance(dao);
     }
 
-    function createCSApps (address root, Kernel dao, string name, bytes32 descHash) internal {
+    function createCSApps (
+        address root,
+        Kernel dao,
+        string spaceName,
+        bytes32 descHash,
+        string coinName,
+        string coinSymbol,
+        uint8 coinDecimals
+    ) internal
+    {
         Space space;
         Coin coin;
 
@@ -97,7 +106,7 @@ contract CoinsenceKit is KitBase {
         );
         emit InstalledApp(coin, appIds[1]);
 
-        initializeCSApps(space, coin, name, descHash);
+        initializeCSApps(space, coin, spaceName, descHash, coinName, coinSymbol, coinDecimals);
 
         handleCSPermissions(dao, space, coin, root);
     }
@@ -105,12 +114,15 @@ contract CoinsenceKit is KitBase {
     function initializeCSApps(
         Space space,
         Coin coin,
-        string name,
-        bytes32 descHash
+        string spaceName,
+        bytes32 descHash,
+        string coinName,
+        string coinSymbol,
+        uint8 coinDecimals
     ) internal
     {
-        space.initialize(name, descHash);
-        coin.initialize();
+        space.initialize(spaceName, descHash);
+        coin.initialize(coinName, coinSymbol, coinDecimals);
     }
 
     function handleCSPermissions(

--- a/apps/coinsence-kit/scripts/new-dao.js
+++ b/apps/coinsence-kit/scripts/new-dao.js
@@ -23,7 +23,7 @@ module.exports = async function(callback) {
 
   let coinsenceKit = CoinsenceKit.at(coinsenceKitAddress)
 
-  coinsenceKit.newInstance(argv.name, argv.ipfs, argv.root).then((ret) => {
+  coinsenceKit.newInstance(argv.spaceName, argv.ipfs, argv.coinName, argv.coinSymbol, argv.coinDecimals, argv.root).then((ret) => {
 
     const installedEvents = ret.logs.filter(log => log.event === 'InstalledApp').map(log => log.args)
     const deployEvents = ret.logs.filter(log => log.event === 'DeployInstance').map(log => log.args)

--- a/apps/coinsence-kit/test/coinsenceKit.js
+++ b/apps/coinsence-kit/test/coinsenceKit.js
@@ -28,7 +28,7 @@ contract('DAO bare kit', (accounts) => {
         });
 
         it('it should deploy DAO', async () => {
-            const receipt = await coinsenceKit.newInstance("coinsence", web3.fromAscii("0"), accounts[0], { from: accounts[0] });
+            const receipt = await coinsenceKit.newInstance("coinsence", web3.fromAscii("0"), "coinsence coin", "CC", 18, accounts[0], { from: accounts[0] });
 
             address = receipt.logs.filter(l => l.event === 'DeployInstance')[0].args.dao
             apps = receipt.logs

--- a/lib/http/apps/dao.js
+++ b/lib/http/apps/dao.js
@@ -3,11 +3,14 @@ const express = require('express');
 const app = express();
 
 app.post(`/`, (req, res) => {
-  let name = req.body.name;
+  let spaceName = req.body.spaceName;
   let descHash = req.body.descHash;
+  let coinName = req.body.coinName;
+  let coinSymbol = req.body.coinSymbol;
+  let coinDecimals = req.body.coinDecimals;
 
-  console.log(`New DAO: ${name} ${descHash} with root: ${res.locals.wallet.address}`);
-  res.locals.kit.newInstance({ name, descHash, root: res.locals.wallet.address }, { gasLimit: 5000000 }).then((dao) => {
+  console.log(`New DAO: ${spaceName} ${descHash} ${coinName} ${coinSymbol} ${coinDecimals}  with root: ${res.locals.wallet.address}`);
+  res.locals.kit.newInstance({ spaceName, descHash, coinName, coinSymbol, coinDecimals, root: res.locals.wallet.address }, { gasLimit: 5000000 }).then((dao) => {
     res.status(201).json(dao);
   }).catch(e => {
     console.log(e);

--- a/lib/kit.js
+++ b/lib/kit.js
@@ -40,9 +40,9 @@ class CoinsenceKit {
   }
 
   newInstance(args, callOptions = {}) {
-    let { name, descHash, root } = args;
+    let { spaceName, descHash, coinName, coinSymbol, coinDecimals, root } = args;
 
-    return this.contract.functions.newInstance(name, descHash, root, callOptions)
+    return this.contract.functions.newInstance(spaceName, descHash, coinName, coinSymbol, coinDecimals, root, callOptions)
       .then(transaction => {
         return transaction.wait().then(result => {
           const txHash = result.transactionHash;


### PR DESCRIPTION
This PR refactor the Coin app and update the Coinsence Kit and the correspondent HTTP calls:

- Remove the `_isIssued` var that indicate if a Coin is issued.
- Issue the Coin at the phase of creating new kit instance (deploying DAO/init the Coin app instance)
- Update Coinsence Kit unit tests & deploying script
- Update Coin unit tests
- Update REST API