### PR TITLE
Environment variable for signer account

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -29,7 +29,7 @@ let ethProvider;
 let coinsenceSigner;
 if (process.env.ETH_PROVIDER_URL) {
   ethProvider = new ethers.providers.JsonRpcProvider(process.env.ETH_PROVIDER_URL);
-  coinsenceSigner = ethProvider.getSigner();
+  coinsenceSigner = ethProvider.getSigner(parseInt(process.env.SIGNER_INDEX));
 } else {
   ethProvider = new ethers.getDefaultProvider('rinkeby'); // TODO: use correct network
   const password = process.env.PASSWORD || 'coinsence'; // TODO: load in memory only


### PR DESCRIPTION
This PR add an environment variable to indicate the index of the signer account to use, as in the case of using GETH node we have to use different signer for each API instance (dev, test or prod platform)