### PR TITLE
Use custom nonce calculation for migration

### DIFF
--- a/lib/http/apps/migrate.js
+++ b/lib/http/apps/migrate.js
@@ -24,7 +24,7 @@ app.post('/space', async (req, res) => {
     if (!Array.isArray(accounts)) {
         res.status(400).json({error: 'accounts is missing'});
     } else {
-        const walletTransactionCount = await kredits.provider.getTransactionCount(kredits.signer.address);
+        const walletTransactionCount = await res.locals.coinsence.provider.getTransactionCount(res.locals.coinsence.signer.address);
         let nonce = walletTransactionCount;
         accounts.forEach((account) => {
             if(account.balance > 0) {

--- a/lib/http/apps/migrate.js
+++ b/lib/http/apps/migrate.js
@@ -8,37 +8,39 @@ const app = express();
  * @apiName PostMigrateSpace
  * @apiGroup Migrate
  * @apiVersion 1.0.0
- * 
+ *
  * @apiParam {Object[]} accounts List of account
  * @apiParam {String}   accounts.address account address
  * @apiParam {String}   accounts.accountId account unique id
  * @apiParam {Number}   accounts.balance account balance
  * @apiParam {Boolean}  accounts.isMember account status(member/space account)
- *  
+ *
  * @apiUse MissingAccountIdError
  * @apiUse MissingDaoError
  */
-app.post('/space', (req, res) => {
+app.post('/space', async (req, res) => {
     const accounts = req.body.accounts;
-  
+
     if (!Array.isArray(accounts)) {
         res.status(400).json({error: 'accounts is missing'});
     } else {
+        const walletTransactionCount = await kredits.provider.getTransactionCount(kredits.signer.address);
+        let nonce = walletTransactionCount;
         accounts.forEach((account) => {
             if(account.balance > 0) {
-                res.locals.coinsence.Coin.functions.mintCoin(account.address, account.balance, { gasLimit: 5000000 }).catch(e => {
+                res.locals.coinsence.Coin.functions.mintCoin(account.address, account.balance, { gasLimit: 5000000, nonce: nonce++ }).catch(e => {
                     console.log(e);
-                });    
+                });
             }
             if(account.isMember == true) {
-                res.locals.coinsence.Space.functions.addMembers([account.address], { gasLimit: 5000000 }).catch(e => {
+                res.locals.coinsence.Space.functions.addMembers([account.address], { gasLimit: 5000000, nonce: nonce++ }).catch(e => {
                     console.log(e);
-                });    
+                });
             }
         });
 
         res.sendStatus(201);
     }
 });
-  
+
 module.exports = app;


### PR DESCRIPTION
The account signer does not know about the amount of published transactions. 
Thus we try to guess the nonces by checking the transactions count and then just counting up. 

This does not fully work as for example a request could happen in parallel, but it could work for now.